### PR TITLE
feat: add imagedelivery.net support

### DIFF
--- a/data/domains.json
+++ b/data/domains.json
@@ -9,5 +9,6 @@
   "s7d1.scene7.com": "scene7",
   "ip.keycdn.com": "keycdn",
   "assets.caisy.io": "bunny",
-  "images.contentstack.io": "contentstack"
+  "images.contentstack.io": "contentstack",
+  "imagedelivery.net": "cloudflare_images"
 }

--- a/src/transformers/cloudflareimages.ts
+++ b/src/transformers/cloudflareimages.ts
@@ -7,10 +7,14 @@ import {
 import { toUrl } from "../utils.ts";
 
 const cloudflareImagesRegex =
-  /https?:\/\/(?<host>[^\/]+)\/cdn-cgi\/imagedelivery\/(?<accountHash>[^\/]+)\/(?<imageId>[^\/]+)\/*(?<transformations>[^\/]+)*$/g;
+  /https?:\/\/(?:(?<host>[^\/]+)\/cdn-cgi\/imagedelivery|imagedelivery.net)\/(?<accountHash>[^\/]+)\/(?<imageId>[^\/]+)\/*(?<transformations>[^\/]+)*$/g;
 
 const parseTransforms = (transformations: string) =>
-  Object.fromEntries(transformations?.split(",")?.map((t) => t.split("=")) ?? []);
+  transformations?.includes("=")
+    ? Object.fromEntries(
+        transformations?.split(",")?.map((t) => t.split("=")) ?? []
+      )
+    : {};
 
 const formatUrl = (
   {
@@ -25,9 +29,7 @@ const formatUrl = (
   ).join(",");
 
   const pathSegments = [
-      host,
-    "cdn-cgi",
-    "imagedelivery",
+    ...(host ? [host, "cdn-cgi", "imagedelivery"] : ["imagedelivery.net"]),
     accountHash,
     imageId,
     transformString,


### PR DESCRIPTION
cloudflare images can either be hosted on the same host (through /cdn-cgi/imagedelivery/)
or directly on imagedelivery.net
Account for this
Also changed transformations as the user could have provided a variant there,
ie /public, and in that case the parser was considering it as a transformation
and keeping /public=&w=X
